### PR TITLE
[JENKINS-49176,JENKINS-49185] - Make the plugin compatible with Jenkins 2.102+ and fix concurrency issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.9</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <artifactId>last-changes</artifactId>
@@ -17,9 +17,6 @@
         <jenkins.version>1.642.1</jenkins.version>
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
         <java.level>7</java.level>
-        <!-- Jenkins Test Harness version you use to test the plugin. -->
-        <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <jenkins-test-harness.version>2.20</jenkins-test-harness.version>
         <!-- Other properties you may want to use:
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
@@ -59,7 +56,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>0.2</version>
+            <version>2.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -68,8 +65,34 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>1.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ssh-credentials</artifactId>
+            <version>1.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.14</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>annotation-indexer</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.5</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -86,8 +109,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.10</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>annotation-indexer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -96,12 +125,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -129,14 +152,14 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <version>1.14</version>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>2.0.4</version>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -144,13 +167,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
 
     </pluginRepositories>
@@ -158,21 +181,6 @@
     <build>
         <finalName>last-changes</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-             <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>2.1</version>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/jenkins/lastchanges/LastChangesPublisher.java
+++ b/src/main/java/com/github/jenkins/lastchanges/LastChangesPublisher.java
@@ -80,8 +80,6 @@ public class LastChangesPublisher extends Recorder implements SimpleBuildStep {
 
     private static final short RECURSION_DEPTH = 50;
 
-    private static final DateFormat DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
-
     private String specificRevision; //revision id to crete the diff
 
     private String specificBuild; // create the diff with the revision of an specific build
@@ -322,7 +320,8 @@ public class LastChangesPublisher extends Recorder implements SimpleBuildStep {
                 @Override
                 public int compare(CommitInfo c1, CommitInfo c2) {
                     try {
-                        return DATE_FORMAT.parse(c1.getCommitDate()).compareTo(DATE_FORMAT.parse(c2.getCommitDate()));
+                        DateFormat format = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
+                        return format.parse(c1.getCommitDate()).compareTo(format.parse(c2.getCommitDate()));
                     } catch (ParseException e) {
                         LOG.severe(String.format("Could not parse commit dates %s and %s ", c1.getCommitDate(), c2.getCommitDate()));
                         return 0;

--- a/src/main/java/com/github/jenkins/lastchanges/model/CommitInfo.java
+++ b/src/main/java/com/github/jenkins/lastchanges/model/CommitInfo.java
@@ -19,7 +19,6 @@ public class CommitInfo implements Serializable {
     private String committerName;
     private String committerEmail;
     private String commitDate;
-    private DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
 
     @Whitelisted
     public String getCommitterName() {
@@ -66,6 +65,7 @@ public class CommitInfo implements Serializable {
 
 
     public String format(Date date, TimeZone tz) {
+        DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
         dateFormat.setTimeZone(tz);
         return dateFormat.format(date);
     }


### PR DESCRIPTION
* [x] SimpleDateFormat is no longer serialized https://issues.jenkins-ci.org/browse/JENKINS-49185
* [x] SimpleDateFormat is no longer used in a thread-unsafe way https://issues.jenkins-ci.org/browse/JENKINS-49176
* [x] Update the plugin to make it runnable in PCT. I confirmed there is no other issues reported

@rmpestano @reviewbybees @jglick 