### PR TITLE
Fix links to images in help

### DIFF
--- a/src/main/resources/com/github/jenkins/lastchanges/LastChangesPublisher/help.html
+++ b/src/main/resources/com/github/jenkins/lastchanges/LastChangesPublisher/help.html
@@ -50,7 +50,7 @@
                     <table>
                         <tbody><tr>
                             <td>
-                                <div><g-emoji alias="information_source" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/2139.png" ios-version="6.0"><img class="emoji" alt=":information_source:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/2139.png"></g-emoji></div>
+                                <div><g-emoji alias="information_source" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2139.png" ios-version="6.0"><img class="emoji" alt=":information_source:" height="20" width="20" src="https://github.githubassets.com/images/icons/emoji/unicode/2139.png"></g-emoji></div>
                             </td>
                             <td>
                                 By default previous revision is <b>current revision -1</b>.
@@ -62,7 +62,7 @@
                     <table>
                         <tbody><tr>
                             <td>
-                                <div><g-emoji alias="bulb" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4a1.png" ios-version="6.0"><img class="emoji" alt=":bulb:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4a1.png"></g-emoji></div>
+                                <div><g-emoji alias="bulb" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f4a1.png" ios-version="6.0"><img class="emoji" alt=":bulb:" height="20" width="20" src="https://github.githubassets.com/images/icons/emoji/unicode/1f4a1.png"></g-emoji></div>
                             </td>
                             <td>
                                 You can use <a href="https://wiki.jenkins.io/display/JENKINS/Parameterized+Build">parameters</a> in <code>SpecificRevision</code>. In case of git, expressions like <code>HEAD^^</code> can be used.


### PR DESCRIPTION
Jenkins.io site uses the content of help section of this plugin (see the screenshot).
[
![2019-10-10 21_21_54-Pipeline_ Basic Steps](https://user-images.githubusercontent.com/1636249/66595890-8af53380-eba4-11e9-8143-5101dd17f8a6.png)
](url)
I've replaced the broken images with valid links.