### PR TITLE
Disable `pluginFirstClassLoader`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,14 +211,6 @@
 				<version>1.16</version>
 			</plugin>
 			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<version>2.2</version>
-				<configuration>
-					<pluginFirstClassLoader>false</pluginFirstClassLoader>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>2.5.1</version>


### PR DESCRIPTION
See [`pluginFirstClassLoader` and its discontents](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#pluginfirstclassloader-and-its-discontents). This mode is not recommended, and I cannot see any reason why this plugin needs it. Simpler to get rid of it.