### PR TITLE
[JENKINS-73781] Make plugin compatible with git client 5.0.0 and 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-aggregator</artifactId>
 			<version>2.5</version>

--- a/src/main/java/com/github/jenkins/lastchanges/impl/GitLastChanges.java
+++ b/src/main/java/com/github/jenkins/lastchanges/impl/GitLastChanges.java
@@ -216,7 +216,7 @@ public class GitLastChanges implements VCSChanges<Repository, ObjectId> {
 
             if (tags != null && !tags.isEmpty()) {
                 Ref tag = tags.get(0);
-                Ref peeledRef = repository.peel(tag);
+                Ref peeledRef = repository.getRefDatabase().peel(tag);
                 LogCommand log = git.log();
                 if (peeledRef.getPeeledObjectId() != null) {
                     log.add(peeledRef.getPeeledObjectId());

--- a/src/test/java/com/github/jenkins/lastchanges/SvnLastChangesTest.java
+++ b/src/test/java/com/github/jenkins/lastchanges/SvnLastChangesTest.java
@@ -51,9 +51,14 @@ public class SvnLastChangesTest {
 
     @Test
     public void shouldGetLastChanges() {
+        String pass = System.getProperty("PASS");
+        if(pass == null || "".equals(pass)) {
+            return;
+        }
         File repository = new File(svnRepoPath);
         assertThat(repository).exists();
-        LastChanges lastChanges = SvnLastChanges.getInstance().changesOf(repository);
+        BasicAuthenticationManager basicAuthenticationManager = new BasicAuthenticationManager("rmpestano@gmail.com",pass);
+        LastChanges lastChanges = SvnLastChanges.getInstance().setSvnAuthManager(basicAuthenticationManager).changesOf(repository);
         assertNotNull(lastChanges);
         assertThat(lastChanges.getCurrentRevision()).isNotNull();
         assertThat(lastChanges.getDiff()).isNotEmpty();


### PR DESCRIPTION
## [JENKINS-73781] Make plugin compatible with git client 5.0.0 and 6.0.0

Replaces JGit `peel()` with `getRefDatabase().peel()`

[JENKINS-73781](https://issues.jenkins.io/browse/JENKINS-73781) notes that JGit deprecated `peel()` in favor of `getRefDatabase().peel()` a long time ago.  The deprecated method was removed from JGit 7.0.0.  This uses the replacement method that has been available since the deprecation.  This change works with both the older JGit versions (6.x) and the most recent JGit 7.0.0 release.

The git client plugin pull request that introduced JGit 7.0.0 is:

* https://github.com/jenkinsci/git-client-plugin/pull/1170

[Git client plugin 6.0.0](https://github.com/jenkinsci/git-client-plugin/releases/tag/git-client-6.0.0) is the git client plugin release that introduced JGit 7.0.0.

The test that is failing on the master branch has been updated to use the same pattern as another test in the same file.  Assembla now requires authenticated access for their Subversion repositories.  The `shouldGetLastChangesFromLatestTag` test already used this same technique to only run the test when the PASS system property is provided.  Make `shouldGetLastChanges` the same as `shouldGetLastChangesFromLatestTag`.

This change ignores `shouldGetLastChanges` on ci.jenkins.io in the same way that `shouldGetLastChangesFromLatestTag` was already ignored, since the `PASS` property is not set on ci.jenkins.io.

### Testing done

Automated tests pass.  No interactive testing has been performed because the changes are minor.  The same change was applied to the git client plugin when it transitioned from JGit 6.10.0 to JGit 7.0.0 and all tests were passing with git client plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
