### PR TITLE
Add Pipeline to Get and Display Latest Changed Files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,33 @@
-// Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+pipeline {
+    agent any
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm // Checkout the code from the repository
+            }
+        }
+
+        stage('Get Latest Changed Files') {
+            steps {
+                script {
+                    // Get the names of the files changed in the latest commit
+                    def changedFiles = sh(script: 'git diff --name-only HEAD~1 HEAD', returnStdout: true).trim().split('\n')
+                    echo "Changed files in the latest commit:"
+                    
+                    // Loop through and print each file name
+                    changedFiles.each { file ->
+                        echo "File: ${file}"
+                    }
+                }
+            }
+        }
+
+        stage('Build Plugin') {
+            steps {
+                // Build the plugin using the shared pipeline library
+                buildPlugin()
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Changes Made:
- Implemented a Jenkins pipeline to fetch and display the names of files changed in the latest commit.
- The pipeline retrieves the file names using `git diff --name-only HEAD~1 HEAD` and displays them in the Jenkins logs.
- This pipeline stage helps track file changes, making it easier for developers to review modified files in each commit.